### PR TITLE
Add data layer abstraction for game data access

### DIFF
--- a/docs/branching.md
+++ b/docs/branching.md
@@ -1,0 +1,11 @@
+# Branch Maintenance
+
+To keep feature branches aligned with the latest changes, regularly rebase on top of `main`:
+
+```bash
+git fetch origin
+git checkout work
+git rebase origin/main
+```
+
+Resolve any conflicts that appear, run the project's checks, and push the updated branch with `--force-with-lease` to avoid overwriting others' work.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type {Metadata} from 'next';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster"
-import { FirebaseClientProvider } from '@/firebase/client-provider';
+import { DataProvider } from '@/data';
 
 export const metadata: Metadata = {
   title: 'Tactical Rainbow Online',
@@ -17,13 +17,13 @@ export default function RootLayout({
     <html lang="es" className="dark">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
       </head>
       <body className="font-body antialiased">
-        <FirebaseClientProvider>
+        <DataProvider>
           {children}
-        </FirebaseClientProvider>
+        </DataProvider>
         <Toaster />
       </body>
     </html>

--- a/src/components/FirebaseErrorListener.tsx
+++ b/src/components/FirebaseErrorListener.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { errorEmitter } from '@/firebase/error-emitter';
-import { FirestorePermissionError } from '@/firebase/errors';
+import { errorEmitter, DataPermissionError } from '@/data';
 
 /**
  * An invisible component that listens for globally emitted 'permission-error' events.
@@ -10,11 +9,11 @@ import { FirestorePermissionError } from '@/firebase/errors';
  */
 export function FirebaseErrorListener() {
   // Use the specific error type for the state for type safety.
-  const [error, setError] = useState<FirestorePermissionError | null>(null);
+  const [error, setError] = useState<DataPermissionError | null>(null);
 
   useEffect(() => {
     // The callback now expects a strongly-typed error, matching the event payload.
-    const handleError = (error: FirestorePermissionError) => {
+    const handleError = (error: DataPermissionError) => {
       // Set error in state to trigger a re-render.
       setError(error);
     };

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useUser, useAuth } from '@/firebase/provider';
-import { initiateAnonymousSignIn } from '@/firebase/non-blocking-login';
+import { useAuthentication } from '@/data';
 import { useEffect } from 'react';
 import { Loader2 } from 'lucide-react';
 
@@ -10,14 +9,13 @@ interface AuthGuardProps {
 }
 
 export function AuthGuard({ children }: AuthGuardProps) {
-  const { user, isUserLoading } = useUser();
-  const auth = useAuth();
+  const { user, isUserLoading, signInAnonymously } = useAuthentication();
 
   useEffect(() => {
     if (!isUserLoading && !user) {
-      initiateAnonymousSignIn(auth);
+      signInAnonymously();
     }
-  }, [user, isUserLoading, auth]);
+  }, [user, isUserLoading, signInAnonymously]);
 
   if (isUserLoading || !user) {
     return (

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { useReducer, useEffect, useState, useRef } from 'react';
+
+import { useReducer, useEffect, useState, useRef, useMemo, useCallback } from 'react';
 import { gameReducer, getInitialGameState } from '@/lib/game-logic';
 import { PlayerHand } from './PlayerHand';
 import { OpponentHand } from './OpponentHand';
@@ -17,11 +18,10 @@ import { useRouter } from 'next/navigation';
 import { isEqual } from 'lodash';
 import { Button } from '@/components/ui/button';
 
-
 function GameLoader() {
   return (
     <div className="w-full max-w-7xl mx-auto flex flex-col gap-4">
-       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <Skeleton className="h-24" />
         <Skeleton className="h-24" />
         <Skeleton className="h-24" />
@@ -31,7 +31,7 @@ function GameLoader() {
       <Skeleton className="h-48" />
       <Skeleton className="h-48" />
     </div>
-  )
+  );
 }
 
 interface GameBoardProps {
@@ -47,57 +47,63 @@ export function GameBoard({ matchId }: GameBoardProps) {
   const { mergeMatch, deleteMatch } = useMatchesActions();
 
   const [state, dispatch] = useReducer(gameReducer, null, () => ({} as GameState));
-  
   const localUpdateRef = useRef(false);
 
-  // Effect to sync remote state (from Firestore) to local state (useReducer)
+  // Effect to sync remote state (from the data provider) to local reducer state.
   useEffect(() => {
     if (match && user) {
       if (match.status === 'PLAYING' && !match.gameState && user.uid === match.player1Id) {
-        // Player 1 is responsible for initializing the game state.
-        const player1: Player = { id: match.player1Id, name: user.displayName || `Jugador ${user.uid.substring(0,5)}`, hand: [], discardPile: [] };
-        const player2: Player = { id: match.player2Id, name: `Jugador ${match.player2Id.substring(0,5)}`, hand: [], discardPile: [] };
+        if (!match.player2Id) {
+          return;
+        }
+
+        const player1: Player = {
+          id: match.player1Id,
+          name: user.displayName || `Jugador ${user.uid.substring(0, 5)}`,
+          hand: [],
+          discardPile: [],
+        };
+        const player2: Player = {
+          id: match.player2Id,
+          name: `Jugador ${match.player2Id.substring(0, 5)}`,
+          hand: [],
+          discardPile: [],
+        };
         const initialState = getInitialGameState([player1, player2]);
         localUpdateRef.current = true;
         void mergeMatch(matchId, { gameState: initialState });
       } else if (match.gameState) {
-        const isPlayerInGame = match.gameState.players.some(p => p.id === user.uid);
-        // Only update local state if it's different from remote state, to avoid loops.
-        // And ensure the local component hasn't just initiated an update.
+        const isPlayerInGame = match.gameState.players.some((p) => p.id === user.uid);
         if (isPlayerInGame && !localUpdateRef.current && !isEqual(state, match.gameState)) {
-            dispatch({ type: 'SET_GAME_STATE', payload: match.gameState });
+          dispatch({ type: 'SET_GAME_STATE', payload: match.gameState });
         }
         if (localUpdateRef.current) {
-            // Clear the flag after a potential local update has been processed.
-            localUpdateRef.current = false;
+          localUpdateRef.current = false;
         }
       }
     }
   }, [match, user, mergeMatch, matchId, state]);
-  
-  // Effect to sync local state changes up to Firestore.
-  useEffect(() => {
-    // Wait until the state is initialized and the user is part of the game.
-    if (!state.phase || !user || !state.players?.find(p => p.id === user.uid) || !match) {
-      return;
-    };
 
-    // If local state is identical to remote state, no update is needed.
-    if (match && isEqual(state, match.gameState)) {
+  // Effect to sync local state changes back to the data provider.
+  useEffect(() => {
+    if (!state.phase || !user || !match || !state.players?.some((p) => p.id === user.uid)) {
       return;
     }
 
-    // Set a flag indicating a local update is happening.
+    if (match.gameState && isEqual(state, match.gameState)) {
+      return;
+    }
+
     localUpdateRef.current = true;
     const updateData = {
       gameState: state,
-      status: state.phase === 'GAME_OVER' ? 'GAME_OVER' : 'PLAYING' as const,
+      status: state.phase === 'GAME_OVER' ? 'GAME_OVER' : ('PLAYING' as const),
     } satisfies Partial<Omit<Match, 'id'>>;
-    void mergeMatch(matchId, updateData);
 
+    void mergeMatch(matchId, updateData);
   }, [state, user, match, mergeMatch, matchId]);
 
-  const handleCancelMatch = async () => {
+  const handleCancelMatch = useCallback(async () => {
     if (!matchId) return;
     setIsCancelling(true);
     try {
@@ -107,9 +113,32 @@ export function GameBoard({ matchId }: GameBoardProps) {
       console.error('Error cancelling match', e);
       setIsCancelling(false);
     }
-  };
+  }, [deleteMatch, matchId, router]);
 
-  // --- Render Logic ---
+  const handlePlayCard = useCallback((handIndex: number, isBlind: boolean) => {
+    dispatch({ type: 'PLAY_CARD', payload: { handIndex, isBlind } });
+  }, []);
+
+  const handleEndTurn = useCallback(() => {
+    dispatch({ type: 'END_TURN' });
+  }, []);
+
+  const handleNextRound = useCallback(() => {
+    dispatch({ type: 'START_NEXT_ROUND' });
+  }, []);
+
+  const handleRestart = useCallback(() => {
+    dispatch({ type: 'RESTART_GAME' });
+  }, []);
+
+  const currentUserId = user?.uid ?? null;
+  const { self, opponent } = useMemo(() => {
+    const players = state?.players ?? [];
+    return {
+      self: currentUserId ? players.find((p) => p.id === currentUserId) : undefined,
+      opponent: currentUserId ? players.find((p) => p.id !== currentUserId) : undefined,
+    };
+  }, [state?.players, currentUserId]);
 
   if (isLoadingMatch || !user) {
     return <GameLoader />;
@@ -117,84 +146,76 @@ export function GameBoard({ matchId }: GameBoardProps) {
 
   if (!match) {
     return (
-        <div className="w-full max-w-2xl mx-auto">
-            <Card>
-                <CardHeader>
-                    <CardTitle>Error de Partida</CardTitle>
-                    <CardDescription>No se pudo encontrar la partida. Puede que haya sido cancelada o que el enlace sea incorrecto.</CardDescription>
-                </CardHeader>
-                <CardFooter>
-                    <Button onClick={() => router.push('/')} className="w-full">Volver al Lobby</Button>
-                </CardFooter>
-            </Card>
-        </div>
+      <div className="w-full max-w-2xl mx-auto flex items-center justify-center min-h-screen">
+        <Card>
+          <CardHeader>
+            <CardTitle>Error de Partida</CardTitle>
+            <CardDescription>
+              No se pudo encontrar la partida. Puede que haya sido cancelada o que el enlace sea incorrecto.
+            </CardDescription>
+          </CardHeader>
+          <CardFooter>
+            <Button onClick={() => router.push('/')} className="w-full">
+              Volver al Lobby
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
     );
   }
 
   if (match.status === 'LOBBY') {
     return (
-        <div className="w-full max-w-2xl mx-auto">
-            <Card>
-                <CardHeader>
-                    <CardTitle className="flex items-center gap-2"><Loader2 className="animate-spin" /> Esperando Oponente</CardTitle>
-                    <CardDescription>La partida comenzará cuando otro jugador se una.</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    {match.isPublic ? (
-                        <p>Esta es una partida pública. Un jugador puede unirse en cualquier momento.</p>
-                    ) : (
-                        <div>
-                            <p>Esta es una partida privada. Comparte el código para que se una tu amigo:</p>
-                            <div className="text-2xl font-bold tracking-widest bg-muted rounded-md p-4 text-center my-2">
-                                {match.joinCode}
-                            </div>
-                        </div>
-                    )}
-                </CardContent>
-                <CardFooter>
-                    <Button variant="outline" onClick={handleCancelMatch} disabled={isCancelling || match.player1Id !== user?.uid} className="w-full">
-                        {isCancelling ? <Loader2 className="animate-spin" /> : "Cancelar Partida"}
-                    </Button>
-                </CardFooter>
-            </Card>
-        </div>
-    )
+      <div className="w-full max-w-2xl mx-auto flex items-center justify-center min-h-screen">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Loader2 className="animate-spin" /> Esperando Oponente
+            </CardTitle>
+            <CardDescription>La partida comenzará cuando otro jugador se una.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {match.isPublic ? (
+              <p>Esta es una partida pública. Un jugador puede unirse en cualquier momento.</p>
+            ) : (
+              <div>
+                <p>Esta es una partida privada. Comparte el código para que se una tu amigo:</p>
+                <div className="text-2xl font-bold tracking-widest bg-muted rounded-md p-4 text-center my-2">
+                  {match.joinCode}
+                </div>
+              </div>
+            )}
+          </CardContent>
+          <CardFooter>
+            <Button
+              variant="outline"
+              onClick={handleCancelMatch}
+              disabled={isCancelling || match.player1Id !== user.uid}
+              className="w-full"
+            >
+              {isCancelling ? <Loader2 className="animate-spin" /> : 'Cancelar Partida'}
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    );
   }
-  
-  if (!state.phase || !match.gameState) {
+
+  if (!state || !state.phase) {
     return <GameLoader />;
   }
 
-
-  const handlePlayCard = (handIndex: number, isBlind: boolean) => {
-    dispatch({ type: 'PLAY_CARD', payload: { handIndex, isBlind } });
-  };
-  
-  const handleEndTurn = () => {
-    dispatch({ type: 'END_TURN' });
-  };
-  
-  const handleNextRound = () => {
-    dispatch({ type: 'START_NEXT_ROUND' });
-  };
-  
-  const handleRestart = () => {
-    dispatch({ type: 'RESTART_GAME' });
-  };
-
-  const self = state.players.find(p => p.id === user.uid);
-  const opponent = state.players.find(p => p.id !== user.uid);
-  
   if (!self || !opponent) {
     return (
-       <div className="flex justify-center items-center h-full text-center text-muted-foreground">
-          <p>Error: No se pudieron cargar los datos de los jugadores. Puede que no formes parte de esta partida.</p>
+      <div className="flex justify-center items-center h-full text-center text-muted-foreground">
+        <p>Error: No se pudieron cargar los datos de los jugadores. Puede que no formes parte de esta partida.</p>
       </div>
     );
   }
 
   const isMyTurn = state.players[state.currentPlayerIndex]?.id === self.id;
   const canPlay = isMyTurn && state.turnState === 'PLAYING' && state.playedCardsThisTurn < 3;
+  const isRoundOver = state.turnState === 'ROUND_OVER';
 
   return (
     <div className="w-full max-w-7xl mx-auto flex flex-col gap-4">
@@ -204,24 +225,13 @@ export function GameBoard({ matchId }: GameBoardProps) {
 
       <CenterRow cards={state.centerRow} />
 
-      <PlayerHand 
-        player={self} 
-        onPlayCard={handlePlayCard} 
-        isCurrentPlayer={isMyTurn} 
-        canPlay={canPlay}
-      />
-      
-      <ActionPanel 
-        state={state} 
-        onEndTurn={handleEndTurn}
-        isMyTurn={isMyTurn}
-        player={self}
-      />
-      
-      {state.turnState === 'ROUND_OVER' && <RoundResultToast state={state} onNextRound={handleNextRound} currentUserId={user.uid} />}
-      
+      <PlayerHand player={self} onPlayCard={handlePlayCard} isCurrentPlayer={isMyTurn} canPlay={canPlay} />
+
+      <ActionPanel state={state} onEndTurn={handleEndTurn} isMyTurn={isMyTurn} player={self} />
+
+      {isRoundOver && <RoundResultToast state={state} onNextRound={handleNextRound} currentUserId={user.uid} />}
+
       <EndGameDialog state={state} onRestart={handleRestart} />
     </div>
   );
 }
-    

--- a/src/components/game/RoundResultToast.tsx
+++ b/src/components/game/RoundResultToast.tsx
@@ -3,7 +3,6 @@ import type { GameState } from '@/lib/types';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Award, ShieldAlert } from 'lucide-react';
-import { useUser } from '@/firebase';
 
 interface RoundResultToastProps {
   state: GameState;

--- a/src/components/lobby/Lobby.tsx
+++ b/src/components/lobby/Lobby.tsx
@@ -6,141 +6,78 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Switch } from '../ui/switch';
-import { useUser, useFirestore, useCollection, useMemoFirebase, FirestorePermissionError, errorEmitter } from '@/firebase';
-import { collection, addDoc, serverTimestamp, query, where, limit, getDocs, doc, updateDoc } from 'firebase/firestore';
+import { useAuthentication, usePublicMatches, useMatchesActions } from '@/data';
 import { useRouter } from 'next/navigation';
-import type { Match } from '@/lib/types';
 import { Loader2 } from 'lucide-react';
-import { getInitialGameState } from '@/lib/game-logic';
-
-function generateJoinCode() {
-  return Math.random().toString(36).substring(2, 8).toUpperCase();
-}
-
-
 export function Lobby() {
   const [isPublic, setIsPublic] = useState(true);
   const [joinCode, setJoinCode] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   
-  const { user } = useUser();
-  const firestore = useFirestore();
+  const { user } = useAuthentication();
   const router = useRouter();
-
-  const publicMatchesQuery = useMemoFirebase(() => 
-    firestore ? query(
-        collection(firestore, 'matches'), 
-        where('isPublic', '==', true),
-        where('status', '==', 'LOBBY'),
-        limit(10)
-    ) : null,
-  [firestore]);
-  
-  const { data: publicMatches, isLoading: isLoadingPublicMatches } = useCollection<Match>(publicMatchesQuery);
+  const { data: publicMatches, isLoading: isLoadingPublicMatches } = usePublicMatches();
+  const { createMatch, findMatchByJoinCode, joinMatch } = useMatchesActions();
 
   const handleCreateGame = async () => {
-    if (!user || !firestore) return;
-    setIsLoading(true);
-    setError(null);
-
-    const newMatch: Omit<Match, 'id'> = {
-        player1Id: user.uid,
-        player2Id: '',
-        status: 'LOBBY',
-        isPublic,
-        joinCode: isPublic ? '' : generateJoinCode(),
-        gameState: null,
-        createdAt: serverTimestamp(),
-        updatedAt: serverTimestamp(),
-    };
-
-    addDoc(collection(firestore, 'matches'), newMatch)
-      .then((docRef) => {
-        router.push(`/game/${docRef.id}`);
-      })
-      .catch((err) => {
-        errorEmitter.emit(
-          'permission-error',
-          new FirestorePermissionError({
-            path: 'matches',
-            operation: 'create',
-            requestResourceData: newMatch,
-          })
-        );
-        setError('No se pudo crear la partida.');
-        setIsLoading(false);
-      });
-  };
-
-  const handleJoinWithCode = async () => {
-    if (!user || !joinCode || !firestore) return;
+    if (!user) return;
     setIsLoading(true);
     setError(null);
     try {
-        const q = query(collection(firestore, "matches"), where("joinCode", "==", joinCode), limit(1));
-        const querySnapshot = await getDocs(q);
-
-        if (querySnapshot.empty) {
-            setError("No se encontró ninguna partida con ese código.");
-            setIsLoading(false);
-            return;
-        }
-        
-        const matchDoc = querySnapshot.docs[0];
-        const match = matchDoc.data() as Match;
-
-        if (match.status !== 'LOBBY') {
-             setError("Esta partida ya ha comenzado.");
-             setIsLoading(false);
-             return;
-        }
-
-        if (match.player1Id === user.uid) {
-            setError("No puedes unirte a tu propia partida.");
-            setIsLoading(false);
-            return;
-        }
-
-        await handleJoinMatch(matchDoc.id);
-
+      const result = await createMatch({ playerId: user.uid, isPublic });
+      router.push(`/game/${result.matchId}`);
     } catch (e) {
-        console.error("Error joining game: ", e);
-        setError("No se pudo unir a la partida.");
+      console.error('Error creating match', e);
+      setError('No se pudo crear la partida.');
+      setIsLoading(false);
+    }
+  };
+
+  const handleJoinWithCode = async () => {
+    if (!user || !joinCode) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const match = await findMatchByJoinCode(joinCode);
+
+      if (!match || !match.id) {
+        setError('No se encontró ninguna partida con ese código.');
         setIsLoading(false);
+        return;
+      }
+
+      if (match.status !== 'LOBBY') {
+        setError('Esta partida ya ha comenzado.');
+        setIsLoading(false);
+        return;
+      }
+
+      if (match.player1Id === user.uid) {
+        setError('No puedes unirte a tu propia partida.');
+        setIsLoading(false);
+        return;
+      }
+
+      await handleJoinMatch(match.id);
+    } catch (e) {
+      console.error('Error joining game: ', e);
+      setError('No se pudo unir a la partida.');
+      setIsLoading(false);
     }
   };
 
   const handleJoinMatch = async (matchId: string) => {
-    if (!user || !firestore) return;
+    if (!user) return;
     setIsLoading(true);
-
-    const matchRef = doc(firestore, 'matches', matchId);
-    
-    // Player 2 just sets their ID and status. 
-    // The GameBoard component for Player 1 will be responsible for creating the initial game state.
-    const updateData = {
-        player2Id: user.uid,
-        status: 'PLAYING' as const,
-        updatedAt: serverTimestamp(),
-    };
-
-    updateDoc(matchRef, updateData)
-      .then(() => {
-        router.push(`/game/${matchId}`);
-      })
-      .catch((err) => {
-        errorEmitter.emit(
-          'permission-error',
-          new FirestorePermissionError({
-            path: `matches/${matchId}`,
-            operation: 'update',
-            requestResourceData: updateData,
-          })
-        );
-        setError("No se pudo unir a la partida. Asegúrate de no unirte a tu propia partida.");
-        setIsLoading(false);
-      });
+    try {
+      await joinMatch(matchId, user.uid);
+      router.push(`/game/${matchId}`);
+    } catch (e) {
+      console.error('Error joining match', e);
+      setError("No se pudo unir a la partida. Asegúrate de no unirte a tu propia partida.");
+      setIsLoading(false);
+    }
   }
 
 
@@ -191,9 +128,9 @@ export function Lobby() {
                         </div>
                     ) : publicMatches && publicMatches.length > 0 ? (
                         publicMatches.map(match => (
-                            <div key={match.id} className="flex justify-between items-center p-2 rounded-md bg-muted/50">
-                                <span>Partida de { 'un jugador'}</span>
-                                <Button size="sm" onClick={() => handleJoinMatch(match.id!)} disabled={isLoading || match.player1Id === user?.uid}>
+                            <div key={match.id ?? match.player1Id} className="flex justify-between items-center p-2 rounded-md bg-muted/50">
+                                <span>Partida de {'un jugador'}</span>
+                                <Button size="sm" onClick={() => match.id && handleJoinMatch(match.id)} disabled={isLoading || match.player1Id === user?.uid}>
                                     {isLoading ? <Loader2 className="animate-spin" /> : "Unirse"}
                                 </Button>
                             </div>

--- a/src/components/lobby/Lobby.tsx
+++ b/src/components/lobby/Lobby.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -9,12 +10,13 @@ import { Switch } from '../ui/switch';
 import { useAuthentication, usePublicMatches, useMatchesActions } from '@/data';
 import { useRouter } from 'next/navigation';
 import { Loader2 } from 'lucide-react';
+
 export function Lobby() {
   const [isPublic, setIsPublic] = useState(true);
   const [joinCode, setJoinCode] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  
+
   const { user } = useAuthentication();
   const router = useRouter();
   const { data: publicMatches, isLoading: isLoadingPublicMatches } = usePublicMatches();
@@ -22,8 +24,10 @@ export function Lobby() {
 
   const handleCreateGame = async () => {
     if (!user) return;
+
     setIsLoading(true);
     setError(null);
+
     try {
       const result = await createMatch({ playerId: user.uid, isPublic });
       router.push(`/game/${result.matchId}`);
@@ -34,10 +38,26 @@ export function Lobby() {
     }
   };
 
+  const handleJoinMatch = async (matchId: string) => {
+    if (!user) return;
+
+    setIsLoading(true);
+    try {
+      await joinMatch(matchId, user.uid);
+      router.push(`/game/${matchId}`);
+    } catch (e) {
+      console.error('Error joining match', e);
+      setError('No se pudo unir a la partida. Asegúrate de no unirte a tu propia partida.');
+      setIsLoading(false);
+    }
+  };
+
   const handleJoinWithCode = async () => {
     if (!user || !joinCode) return;
+
     setIsLoading(true);
     setError(null);
+
     try {
       const match = await findMatchByJoinCode(joinCode);
 
@@ -67,27 +87,17 @@ export function Lobby() {
     }
   };
 
-  const handleJoinMatch = async (matchId: string) => {
-    if (!user) return;
-    setIsLoading(true);
-    try {
-      await joinMatch(matchId, user.uid);
-      router.push(`/game/${matchId}`);
-    } catch (e) {
-      console.error('Error joining match', e);
-      setError("No se pudo unir a la partida. Asegúrate de no unirte a tu propia partida.");
-      setIsLoading(false);
-    }
-  }
-
-
   return (
     <div className="max-w-2xl mx-auto">
       {error && <p className="text-destructive text-center mb-4">{error}</p>}
       <Tabs defaultValue="join">
         <TabsList className="grid w-full grid-cols-2">
-          <TabsTrigger value="join" disabled={isLoading}>Unirse a Partida</TabsTrigger>
-          <TabsTrigger value="create" disabled={isLoading}>Crear Partida</TabsTrigger>
+          <TabsTrigger value="join" disabled={isLoading}>
+            Unirse a Partida
+          </TabsTrigger>
+          <TabsTrigger value="create" disabled={isLoading}>
+            Crear Partida
+          </TabsTrigger>
         </TabsList>
         <TabsContent value="join">
           <Card>
@@ -99,15 +109,15 @@ export function Lobby() {
               <div className="space-y-2">
                 <Label htmlFor="join-code">Código de Partida Privada</Label>
                 <div className="flex gap-2">
-                  <Input 
-                    id="join-code" 
-                    placeholder="Introduce el código" 
+                  <Input
+                    id="join-code"
+                    placeholder="Introduce el código"
                     value={joinCode}
                     onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
                     disabled={isLoading}
                   />
                   <Button onClick={handleJoinWithCode} disabled={!joinCode || isLoading}>
-                    {isLoading ? <Loader2 className="animate-spin" /> : "Unirse"}
+                    {isLoading ? <Loader2 className="animate-spin" /> : 'Unirse'}
                   </Button>
                 </div>
               </div>
@@ -120,26 +130,30 @@ export function Lobby() {
                 </div>
               </div>
               <div>
-                <CardTitle className='text-lg mb-2'>Partidas Públicas</CardTitle>
+                <CardTitle className="text-lg mb-2">Partidas Públicas</CardTitle>
                 <div className="border rounded-lg p-4 min-h-[10rem] space-y-2">
-                    {isLoadingPublicMatches ? (
-                        <div className="flex justify-center items-center h-full">
-                            <Loader2 className="animate-spin text-muted-foreground" />
-                        </div>
-                    ) : publicMatches && publicMatches.length > 0 ? (
-                        publicMatches.map(match => (
-                            <div key={match.id ?? match.player1Id} className="flex justify-between items-center p-2 rounded-md bg-muted/50">
-                                <span>Partida de {'un jugador'}</span>
-                                <Button size="sm" onClick={() => match.id && handleJoinMatch(match.id)} disabled={isLoading || match.player1Id === user?.uid}>
-                                    {isLoading ? <Loader2 className="animate-spin" /> : "Unirse"}
-                                </Button>
-                            </div>
-                        ))
-                    ) : (
-                         <div className="flex justify-center items-center h-full text-center text-muted-foreground">
-                            <p>No hay partidas públicas disponibles.</p>
-                        </div>
-                    )}
+                  {isLoadingPublicMatches ? (
+                    <div className="flex justify-center items-center h-full">
+                      <Loader2 className="animate-spin text-muted-foreground" />
+                    </div>
+                  ) : publicMatches && publicMatches.length > 0 ? (
+                    publicMatches.map((match) => (
+                      <div key={match.id} className="flex justify-between items-center p-2 rounded-md bg-muted/50">
+                        <span>Partida de {'un jugador'}</span>
+                        <Button
+                          size="sm"
+                          onClick={() => match.id && handleJoinMatch(match.id)}
+                          disabled={isLoading || match.player1Id === user?.uid}
+                        >
+                          {isLoading ? <Loader2 className="animate-spin" /> : 'Unirse'}
+                        </Button>
+                      </div>
+                    ))
+                  ) : (
+                    <div className="flex justify-center items-center h-full text-center text-muted-foreground">
+                      <p>No hay partidas públicas disponibles.</p>
+                    </div>
+                  )}
                 </div>
               </div>
             </CardContent>
@@ -154,17 +168,13 @@ export function Lobby() {
             <CardContent className="space-y-6">
               <div className="flex items-center space-x-4 rounded-md border p-4">
                 <div className="flex-1 space-y-1">
-                  <p className="text-sm font-medium leading-none">
-                    Partida Pública
-                  </p>
-                  <p className="text-sm text-muted-foreground">
-                    Tu partida será visible para todos en el lobby.
-                  </p>
+                  <p className="text-sm font-medium leading-none">Partida Pública</p>
+                  <p className="text-sm text-muted-foreground">Tu partida será visible para todos en el lobby.</p>
                 </div>
                 <Switch checked={isPublic} onCheckedChange={setIsPublic} disabled={isLoading} />
               </div>
-               <Button onClick={handleCreateGame} className="w-full" disabled={isLoading}>
-                {isLoading ? <Loader2 className="animate-spin" /> : "Crear Partida"}
+              <Button onClick={handleCreateGame} className="w-full" disabled={isLoading}>
+                {isLoading ? <Loader2 className="animate-spin" /> : 'Crear Partida'}
               </Button>
             </CardContent>
           </Card>

--- a/src/data/auth.ts
+++ b/src/data/auth.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useUser, useAuth } from '@/firebase/provider';
+import { initiateAnonymousSignIn } from '@/firebase/non-blocking-login';
+
+export function useAuthentication() {
+  const { user, isUserLoading, userError } = useUser();
+  const auth = useAuth();
+
+  const signInAnonymously = useCallback(() => {
+    initiateAnonymousSignIn(auth);
+  }, [auth]);
+
+  return {
+    user,
+    isUserLoading,
+    userError,
+    signInAnonymously,
+  };
+}

--- a/src/data/context.tsx
+++ b/src/data/context.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import type { MatchesService } from '@/data/matches/types';
+
+export interface DataServices {
+  matches: MatchesService;
+}
+
+const DataContext = createContext<DataServices | null>(null);
+
+export function DataServicesProvider({
+  value,
+  children,
+}: {
+  value: DataServices;
+  children: React.ReactNode;
+}) {
+  return <DataContext.Provider value={value}>{children}</DataContext.Provider>;
+}
+
+export function useDataServices(): DataServices {
+  const context = useContext(DataContext);
+
+  if (!context) {
+    throw new Error('useDataServices must be used within a DataServicesProvider');
+  }
+
+  return context;
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,0 +1,4 @@
+export * from './provider';
+export * from './matches';
+export * from './shared-errors';
+export * from './auth';

--- a/src/data/matches/hooks.ts
+++ b/src/data/matches/hooks.ts
@@ -1,0 +1,120 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { Match } from '@/lib/types';
+import { useDataServices } from '@/data/context';
+import type { CreateMatchInput, CreateMatchResult } from '@/data/matches/types';
+
+interface AsyncState<T> {
+  data: T;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const initialCollectionState: AsyncState<Match[] | null> = {
+  data: null,
+  isLoading: true,
+  error: null,
+};
+
+const initialMatchState: AsyncState<Match | null> = {
+  data: null,
+  isLoading: true,
+  error: null,
+};
+
+export function usePublicMatches() {
+  const { matches } = useDataServices();
+  const [state, setState] = useState(initialCollectionState);
+
+  useEffect(() => {
+    setState({ ...initialCollectionState });
+
+    const unsubscribe = matches.subscribeToPublicMatches(
+      (data) => {
+        setState({ data, isLoading: false, error: null });
+      },
+      (error) => {
+        setState({ data: null, isLoading: false, error });
+      },
+    );
+
+    return unsubscribe;
+  }, [matches]);
+
+  return state;
+}
+
+export function useMatch(matchId: string | null) {
+  const { matches } = useDataServices();
+  const [state, setState] = useState(initialMatchState);
+
+  useEffect(() => {
+    if (!matchId) {
+      setState({ data: null, isLoading: false, error: null });
+      return;
+    }
+
+    setState({ data: null, isLoading: true, error: null });
+
+    const unsubscribe = matches.subscribeToMatch(
+      matchId,
+      (data) => {
+        setState({ data, isLoading: false, error: null });
+      },
+      (error) => {
+        setState({ data: null, isLoading: false, error });
+      },
+    );
+
+    return unsubscribe;
+  }, [matches, matchId]);
+
+  return state;
+}
+
+export function useMatchesActions() {
+  const { matches } = useDataServices();
+
+  const createMatch = useCallback(
+    (input: CreateMatchInput): Promise<CreateMatchResult> => matches.createMatch(input),
+    [matches],
+  );
+
+  const findMatchByJoinCode = useCallback(
+    (joinCode: string) => matches.findMatchByJoinCode(joinCode),
+    [matches],
+  );
+
+  const joinMatch = useCallback(
+    (matchId: string, playerId: string) => matches.joinMatch(matchId, playerId),
+    [matches],
+  );
+
+  const updateMatch = useCallback(
+    (matchId: string, data: Partial<Omit<Match, 'id'>>) => matches.updateMatch(matchId, data),
+    [matches],
+  );
+
+  const mergeMatch = useCallback(
+    (matchId: string, data: Partial<Omit<Match, 'id'>>) => matches.mergeMatch(matchId, data),
+    [matches],
+  );
+
+  const deleteMatch = useCallback(
+    (matchId: string) => matches.deleteMatch(matchId),
+    [matches],
+  );
+
+  return useMemo(
+    () => ({
+      createMatch,
+      findMatchByJoinCode,
+      joinMatch,
+      updateMatch,
+      mergeMatch,
+      deleteMatch,
+    }),
+    [createMatch, findMatchByJoinCode, joinMatch, updateMatch, mergeMatch, deleteMatch],
+  );
+}

--- a/src/data/matches/index.ts
+++ b/src/data/matches/index.ts
@@ -1,0 +1,2 @@
+export * from './hooks';
+export * from './types';

--- a/src/data/matches/services/firebase.ts
+++ b/src/data/matches/services/firebase.ts
@@ -1,0 +1,165 @@
+import { addDoc, collection, deleteDoc, doc, getDocs, limit, onSnapshot, query, serverTimestamp, updateDoc, where, setDoc, type QueryDocumentSnapshot, type DocumentSnapshot } from 'firebase/firestore';
+import type { Firestore } from 'firebase/firestore';
+import type { Match } from '@/lib/types';
+import type { MatchesService, CreateMatchInput, CreateMatchResult } from '@/data/matches/types';
+import { errorEmitter, DataPermissionError } from '@/data/shared-errors';
+
+function mapMatchSnapshot(snapshot: DocumentSnapshot | QueryDocumentSnapshot): Match {
+  const data = snapshot.data() as Match | undefined;
+
+  if (!data) {
+    throw new Error('Match data is undefined');
+  }
+
+  return { ...data, id: snapshot.id };
+}
+
+export class FirebaseMatchesService implements MatchesService {
+  constructor(private readonly firestore: Firestore) {}
+
+  subscribeToPublicMatches(onData: (matches: Match[]) => void, onError: (error: Error) => void) {
+    const publicMatchesQuery = query(
+      collection(this.firestore, 'matches'),
+      where('isPublic', '==', true),
+      where('status', '==', 'LOBBY'),
+      limit(10),
+    );
+
+    return onSnapshot(
+      publicMatchesQuery,
+      (snapshot) => {
+        const matches = snapshot.docs.map((docSnapshot) => mapMatchSnapshot(docSnapshot));
+        onData(matches);
+      },
+      (error) => {
+        const contextualError = new DataPermissionError({ path: 'matches', operation: 'list' });
+        errorEmitter.emit('permission-error', contextualError);
+        onError(contextualError);
+      },
+    );
+  }
+
+  subscribeToMatch(matchId: string, onData: (match: Match | null) => void, onError: (error: Error) => void) {
+    const matchRef = doc(this.firestore, 'matches', matchId);
+
+    return onSnapshot(
+      matchRef,
+      (snapshot) => {
+        if (!snapshot.exists()) {
+          onData(null);
+          return;
+        }
+        onData(mapMatchSnapshot(snapshot));
+      },
+      () => {
+        const contextualError = new DataPermissionError({ path: `matches/${matchId}`, operation: 'get' });
+        errorEmitter.emit('permission-error', contextualError);
+        onError(contextualError);
+      },
+    );
+  }
+
+  async createMatch(input: CreateMatchInput): Promise<CreateMatchResult> {
+    const newMatch: Omit<Match, 'id'> = {
+      player1Id: input.playerId,
+      player2Id: '',
+      status: 'LOBBY',
+      isPublic: input.isPublic,
+      joinCode: input.isPublic ? '' : this.generateJoinCode(),
+      gameState: null,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    };
+
+    try {
+      const docRef = await addDoc(collection(this.firestore, 'matches'), newMatch);
+      return { matchId: docRef.id, joinCode: newMatch.joinCode };
+    } catch (error) {
+      const contextualError = new DataPermissionError({ path: 'matches', operation: 'create', requestResourceData: newMatch });
+      errorEmitter.emit('permission-error', contextualError);
+      throw contextualError;
+    }
+  }
+
+  async findMatchByJoinCode(joinCode: string): Promise<Match | null> {
+    const joinQuery = query(
+      collection(this.firestore, 'matches'),
+      where('joinCode', '==', joinCode),
+      limit(1),
+    );
+
+    try {
+      const snapshot = await getDocs(joinQuery);
+
+      if (snapshot.empty) {
+        return null;
+      }
+
+      return mapMatchSnapshot(snapshot.docs[0]);
+    } catch (error) {
+      const contextualError = new DataPermissionError({ path: 'matches', operation: 'list' });
+      errorEmitter.emit('permission-error', contextualError);
+      throw contextualError;
+    }
+  }
+
+  async joinMatch(matchId: string, playerId: string): Promise<void> {
+    const update = {
+      player2Id: playerId,
+      status: 'PLAYING' as const,
+      updatedAt: serverTimestamp(),
+    } satisfies Partial<Omit<Match, 'id'>>;
+
+    try {
+      await updateDoc(doc(this.firestore, 'matches', matchId), update);
+    } catch (error) {
+      const contextualError = new DataPermissionError({ path: `matches/${matchId}`, operation: 'update', requestResourceData: update });
+      errorEmitter.emit('permission-error', contextualError);
+      throw contextualError;
+    }
+  }
+
+  async updateMatch(matchId: string, data: Partial<Omit<Match, 'id'>>): Promise<void> {
+    const payload = {
+      ...data,
+      updatedAt: data.updatedAt ?? serverTimestamp(),
+    } satisfies Partial<Omit<Match, 'id'>>;
+
+    try {
+      await updateDoc(doc(this.firestore, 'matches', matchId), payload);
+    } catch (error) {
+      const contextualError = new DataPermissionError({ path: `matches/${matchId}`, operation: 'update', requestResourceData: payload });
+      errorEmitter.emit('permission-error', contextualError);
+      throw contextualError;
+    }
+  }
+
+  async mergeMatch(matchId: string, data: Partial<Omit<Match, 'id'>>): Promise<void> {
+    const payload = {
+      ...data,
+      updatedAt: data.updatedAt ?? serverTimestamp(),
+    } satisfies Partial<Omit<Match, 'id'>>;
+
+    try {
+      await setDoc(doc(this.firestore, 'matches', matchId), payload, { merge: true });
+    } catch (error) {
+      const contextualError = new DataPermissionError({ path: `matches/${matchId}`, operation: 'write', requestResourceData: payload });
+      errorEmitter.emit('permission-error', contextualError);
+      throw contextualError;
+    }
+  }
+
+  async deleteMatch(matchId: string): Promise<void> {
+    try {
+      await deleteDoc(doc(this.firestore, 'matches', matchId));
+    } catch (error) {
+      const contextualError = new DataPermissionError({ path: `matches/${matchId}`, operation: 'delete' });
+      errorEmitter.emit('permission-error', contextualError);
+      throw contextualError;
+    }
+  }
+
+  private generateJoinCode() {
+    return Math.random().toString(36).substring(2, 8).toUpperCase();
+  }
+}

--- a/src/data/matches/types.ts
+++ b/src/data/matches/types.ts
@@ -1,0 +1,29 @@
+import type { Match } from '@/lib/types';
+
+export interface CreateMatchInput {
+  playerId: string;
+  isPublic: boolean;
+}
+
+export interface CreateMatchResult {
+  matchId: string;
+  joinCode?: string;
+}
+
+export interface MatchesService {
+  subscribeToPublicMatches(
+    onData: (matches: Match[]) => void,
+    onError: (error: Error) => void,
+  ): () => void;
+  subscribeToMatch(
+    matchId: string,
+    onData: (match: Match | null) => void,
+    onError: (error: Error) => void,
+  ): () => void;
+  createMatch(input: CreateMatchInput): Promise<CreateMatchResult>;
+  findMatchByJoinCode(joinCode: string): Promise<Match | null>;
+  joinMatch(matchId: string, playerId: string): Promise<void>;
+  updateMatch(matchId: string, data: Partial<Omit<Match, 'id'>>): Promise<void>;
+  mergeMatch(matchId: string, data: Partial<Omit<Match, 'id'>>): Promise<void>;
+  deleteMatch(matchId: string): Promise<void>;
+}

--- a/src/data/provider.tsx
+++ b/src/data/provider.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { ReactNode, useMemo } from 'react';
+import { FirebaseClientProvider } from '@/firebase/client-provider';
+import { useFirebase } from '@/firebase/provider';
+import { FirebaseMatchesService } from '@/data/matches/services/firebase';
+import { DataServicesProvider } from '@/data/context';
+
+function FirebaseDataBridge({ children }: { children: ReactNode }) {
+  const { firestore } = useFirebase();
+
+  const services = useMemo(() => ({
+    matches: new FirebaseMatchesService(firestore),
+  }), [firestore]);
+
+  return <DataServicesProvider value={services}>{children}</DataServicesProvider>;
+}
+
+export function DataProvider({ children }: { children: ReactNode }) {
+  return (
+    <FirebaseClientProvider>
+      <FirebaseDataBridge>{children}</FirebaseDataBridge>
+    </FirebaseClientProvider>
+  );
+}

--- a/src/data/shared-errors.ts
+++ b/src/data/shared-errors.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { errorEmitter as firebaseErrorEmitter } from '@/firebase/error-emitter';
+import { FirestorePermissionError } from '@/firebase/errors';
+
+type PermissionErrorContext = {
+  path: string;
+  operation: 'get' | 'list' | 'create' | 'update' | 'delete' | 'write';
+  requestResourceData?: any;
+};
+
+export class DataPermissionError extends Error {
+  public readonly request: FirestorePermissionError['request'];
+
+  constructor(context: PermissionErrorContext) {
+    const firebaseError = new FirestorePermissionError(context);
+    super(firebaseError.message);
+    this.name = 'DataPermissionError';
+    this.request = firebaseError.request;
+  }
+}
+
+export const errorEmitter = firebaseErrorEmitter;

--- a/src/lib/game-logic.ts
+++ b/src/lib/game-logic.ts
@@ -45,11 +45,11 @@ export function getInitialGameState(players: Player[]): GameState {
   const initialDeck = createDeck();
   
   // Ensure players array is valid and reset their state
-  const validatedPlayers = players.map(p => {
+  const validatedPlayers = players.map<Player>(p => {
       if (!p || !p.id || !p.name) {
           throw new Error("Invalid player object provided to getInitialGameState");
       }
-      return { ...p, hand: [], discardPile: [] };
+      return { ...p, hand: [] as Card[], discardPile: [] as Card[] };
   });
   
   // Deal cards

--- a/src/lib/game-logic.ts
+++ b/src/lib/game-logic.ts
@@ -1,6 +1,6 @@
-
 'use client';
-import type { GameState, Player, Card, Color, CenterRowCard, TurnState, RowState, GamePhase } from './types';
+
+import type { GameState, Player, Card, Color, CenterRowCard, GamePhase } from './types';
 
 // --- CONSTANTS ---
 const HAND_SIZE = 3;
@@ -9,29 +9,33 @@ const TURN_TIME_SECONDS = 60;
 // --- DECK CREATION ---
 function createDeck(): Card[] {
   const colorCounts: Record<Color, number> = {
-    Red: 6, Orange: 6, Yellow: 6, Green: 6, Blue: 6, Indigo: 6, Violet: 6,
-    White: 8, Black: 6,
+    Red: 6,
+    Orange: 6,
+    Yellow: 6,
+    Green: 6,
+    Blue: 6,
+    Indigo: 6,
+    Violet: 6,
+    White: 8,
+    Black: 6,
   };
 
   const colors: Color[] = [];
-  // Using Object.keys on colorCounts to ensure we iterate through all defined colors
-  (Object.keys(colorCounts) as Color[]).forEach(color => {
+  (Object.keys(colorCounts) as Color[]).forEach((color) => {
     for (let i = 0; i < colorCounts[color]; i++) {
       colors.push(color);
     }
   });
 
-
   const frontColors = [...colors];
   const backColors = [...colors].sort(() => 0.5 - Math.random());
 
-  let deck = frontColors.map((frontColor, i) => ({
-    id: i,
+  const deck = frontColors.map((frontColor, index) => ({
+    id: index,
     frontColor,
-    backColor: backColors[i],
+    backColor: backColors[index],
   }));
 
-  // Fisher-Yates shuffle
   for (let i = deck.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [deck[i], deck[j]] = [deck[j], deck[i]];
@@ -43,24 +47,22 @@ function createDeck(): Card[] {
 // --- INITIAL STATE ---
 export function getInitialGameState(players: Player[]): GameState {
   const initialDeck = createDeck();
-  
-  // Ensure players array is valid and reset their state
-  const validatedPlayers = players.map<Player>(p => {
-      if (!p || !p.id || !p.name) {
-          throw new Error("Invalid player object provided to getInitialGameState");
-      }
-      return { ...p, hand: [] as Card[], discardPile: [] as Card[] };
+
+  const validatedPlayers = players.map<Player>((player) => {
+    if (!player || !player.id || !player.name) {
+      throw new Error('Invalid player object provided to getInitialGameState');
+    }
+
+    return { ...player, hand: [] as Card[], discardPile: [] as Card[] };
   });
-  
-  // Deal cards
-  validatedPlayers.forEach(player => {
+
+  validatedPlayers.forEach((player) => {
     for (let i = 0; i < HAND_SIZE; i++) {
       if (initialDeck.length > 0) {
         player.hand.push(initialDeck.pop()!);
       }
     }
   });
-
 
   return {
     phase: 'PLAYING',
@@ -75,16 +77,15 @@ export function getInitialGameState(players: Player[]): GameState {
     gameWinnerId: null,
     isTie: false,
     lastActionLog: 'La partida ha comenzado.',
-    turnTimer: TURN_TIME_SECONDS
+    turnTimer: TURN_TIME_SECONDS,
   };
 }
 
 // --- GAME LOGIC HELPERS ---
-function checkRowState(centerRow: CenterRowCard[]): { state: RowState; color?: Color } {
+function checkRowState(centerRow: CenterRowCard[]): { state: 'VALID' | 'BLACK_CARD' | 'DUPLICATE_COLOR'; color?: Color } {
   const visibleColors = new Set<Color>();
   for (const card of centerRow) {
-    // Only check face-up cards for duplicates/black cards
-    if(card.isFaceUp) {
+    if (card.isFaceUp) {
       const color = card.frontColor;
       if (color === 'Black') {
         return { state: 'BLACK_CARD' };
@@ -101,7 +102,12 @@ function checkRowState(centerRow: CenterRowCard[]): { state: RowState; color?: C
 }
 
 function isRainbowComplete(centerRow: CenterRowCard[]): boolean {
-  const uniqueColors = new Set(centerRow.filter(c => c.isFaceUp).map(c => c.frontColor).filter(c => c !== 'White'));
+  const uniqueColors = new Set(
+    centerRow
+      .filter((card) => card.isFaceUp)
+      .map((card) => card.frontColor)
+      .filter((color) => color !== 'White'),
+  );
   return uniqueColors.size >= 6;
 }
 
@@ -114,152 +120,123 @@ export type GameAction =
   | { type: 'RESTART_GAME' }
   | { type: 'TICK_TIMER' };
 
-
 export function gameReducer(state: GameState, action: GameAction): GameState {
-   if (action.type === 'SET_GAME_STATE') {
+  if (action.type === 'SET_GAME_STATE') {
     return action.payload;
   }
-   if (!state || !state.phase) {
-    return {} as GameState; // Return empty state if not initialized
+
+  if (!state || !state.phase) {
+    return state;
   }
 
   if (state.phase !== 'PLAYING') {
     if (action.type === 'RESTART_GAME' && state.players.length === 2) {
-       const newPlayerObjects = state.players.map(p => ({ ...p, hand: [], discardPile: [] }));
-       return getInitialGameState(newPlayerObjects);
+      const newPlayerObjects = state.players.map((player) => ({ ...player, hand: [], discardPile: [] }));
+      return getInitialGameState(newPlayerObjects);
     }
     return state;
   }
-  
+
   switch (action.type) {
     case 'PLAY_CARD': {
       const { handIndex, isBlind } = action.payload;
       const currentPlayer = state.players[state.currentPlayerIndex];
       const cardToPlay = currentPlayer.hand[handIndex];
-      
-      if (!cardToPlay || state.turnState === 'ROUND_OVER' || state.playedCardsThisTurn >= 3) return state;
 
-      const newHand = currentPlayer.hand.filter((_, i) => i !== handIndex);
-      
-      const cardForCenter: Card = { 
-        ...cardToPlay, 
+      if (!cardToPlay || state.turnState === 'ROUND_OVER' || state.playedCardsThisTurn >= 3) {
+        return state;
+      }
+
+      const newHand = currentPlayer.hand.filter((_, index) => index !== handIndex);
+      const cardForCenter: Card = {
+        ...cardToPlay,
         frontColor: isBlind ? cardToPlay.backColor : cardToPlay.frontColor,
         backColor: isBlind ? cardToPlay.frontColor : cardToPlay.backColor,
       };
-      
-      const newCenterRowCard: CenterRowCard = { 
+
+      const newCenterRowCard: CenterRowCard = {
         ...cardForCenter,
-        isFaceUp: true, // Card is always face up when played
+        isFaceUp: true,
       };
 
-      const logMessage = isBlind 
+      const logMessage = isBlind
         ? `${currentPlayer.name} jugó una carta a ciegas, revelando un ${newCenterRowCard.frontColor}.`
         : `${currentPlayer.name} jugó un ${newCenterRowCard.frontColor}.`;
 
-      const newState: GameState = {
+      const tempState: GameState = {
         ...state,
-        players: state.players.map((p, i) => i === state.currentPlayerIndex ? { ...p, hand: newHand } : p),
+        players: state.players.map((player, index) =>
+          index === state.currentPlayerIndex ? { ...player, hand: newHand } : player,
+        ),
         centerRow: [...state.centerRow, newCenterRowCard],
         playedCardsThisTurn: state.playedCardsThisTurn + 1,
-        lastActionLog: logMessage
+        lastActionLog: logMessage,
       };
-      
-      const { state: rowState, color: duplicateColor } = checkRowState(newState.centerRow);
-      
+
+      const { state: rowState, color: duplicateColor } = checkRowState(tempState.centerRow);
+
       if (rowState === 'BLACK_CARD') {
-        return { ...newState, turnState: 'ROUND_OVER', roundEndReason: 'BLACK_CARD', lastActionLog: `${currentPlayer.name} reveló una carta Negra y perdió la ronda.` };
+        return {
+          ...tempState,
+          turnState: 'ROUND_OVER',
+          roundEndReason: 'BLACK_CARD',
+          lastActionLog: `${currentPlayer.name} reveló una carta Negra y perdió la ronda.`,
+        };
       }
+
       if (rowState === 'DUPLICATE_COLOR') {
-        return { ...newState, turnState: 'ROUND_OVER', roundEndReason: 'DUPLICATE_COLOR', lastActionLog: `${currentPlayer.name} reveló un color repetido (${duplicateColor}) y perdió la ronda.` };
+        return {
+          ...tempState,
+          turnState: 'ROUND_OVER',
+          roundEndReason: 'DUPLICATE_COLOR',
+          lastActionLog: `${currentPlayer.name} reveló un color repetido (${duplicateColor}) y perdió la ronda.`,
+        };
       }
-      if (isRainbowComplete(newState.centerRow)) {
-        return { ...newState, turnState: 'ROUND_OVER', roundEndReason: 'RAINBOW_COMPLETE', lastActionLog: `${currentPlayer.name} completó un ARCOÍRIS!` };
+
+      if (isRainbowComplete(tempState.centerRow)) {
+        return {
+          ...tempState,
+          turnState: 'ROUND_OVER',
+          roundEndReason: 'RAINBOW_COMPLETE',
+          lastActionLog: `${currentPlayer.name} completó un ARCOÍRIS!`,
+        };
       }
-      
-      return newState;
+
+      return tempState;
     }
 
     case 'END_TURN': {
-       return endTurn(state);
+      return endTurn(state);
     }
 
     case 'START_NEXT_ROUND': {
-      if (!state.roundEndReason) return state;
-
-      let roundWinnerIndex: number;
-      let nextPlayerIndex: number;
-      
-      const newPlayers = JSON.parse(JSON.stringify(state.players));
-      const cardsToAward = state.centerRow.map(c => ({...c, isFaceUp: true} as Card));
-
-      if (state.roundEndReason === 'RAINBOW_COMPLETE') {
-        roundWinnerIndex = state.currentPlayerIndex;
-        // The opponent of the winner starts the next round.
-        nextPlayerIndex = (roundWinnerIndex + 1) % 2;
-        newPlayers[roundWinnerIndex].discardPile.push(...cardsToAward);
-      } else { // DUPLICATE_COLOR or BLACK_CARD
-        roundWinnerIndex = (state.currentPlayerIndex + 1) % 2;
-        // The player who lost the round starts the next round.
-        nextPlayerIndex = state.currentPlayerIndex;
-        newPlayers[roundWinnerIndex].discardPile.push(...cardsToAward);
-      }
-      const roundWinnerId = newPlayers[roundWinnerIndex].id;
-      
-      // Draw cards
-      const newDeck = [...state.deck];
-      let isGameOver = false;
-      
-      for (let i = 0; i < newPlayers.length; i++) {
-        const player = newPlayers[i];
-        const cardsNeeded = HAND_SIZE - player.hand.length;
-        if (cardsNeeded > 0) {
-          for(let j = 0; j < cardsNeeded; j++) {
-            if (newDeck.length > 0) {
-              player.hand.push(newDeck.pop()!);
-            } else {
-              isGameOver = true;
-              break;
-            }
-          }
-        }
-        if (isGameOver) break;
-      }
-      
-      const updatedState: GameState = {
-        ...state,
-        players: newPlayers,
-        deck: newDeck,
-        centerRow: [], // Clear the center row
-        currentPlayerIndex: nextPlayerIndex as 0 | 1,
-        turnState: 'PLAYING',
-        playedCardsThisTurn: 0,
-        roundEndReason: null,
-        roundWinnerId,
-        lastActionLog: `${newPlayers[roundWinnerIndex].name} ganó la ronda. ${newPlayers[nextPlayerIndex].name} empieza.`,
-        turnTimer: TURN_TIME_SECONDS
-      };
-      
-      if(isGameOver) {
-        return checkGameOver(updatedState);
-      }
-      
-      return updatedState;
-    }
-    
-    case 'RESTART_GAME':
-       if (state.players.length === 2) {
-          const newPlayerObjects = state.players.map(p => ({ id: p.id, name: p.name, hand: [], discardPile: [] }));
-          return getInitialGameState(newPlayerObjects);
-        }
+      if (!state.roundEndReason) {
         return state;
-      
+      }
+      return startNextRound(state);
+    }
+
+    case 'RESTART_GAME': {
+      if (state.players.length === 2) {
+        const newPlayerObjects = state.players.map((player) => ({ id: player.id, name: player.name, hand: [], discardPile: [] }));
+        return getInitialGameState(newPlayerObjects);
+      }
+      return state;
+    }
+
     case 'TICK_TIMER': {
-       if (state.phase !== 'PLAYING' || state.turnState !== 'PLAYING') return state;
+      if (state.phase !== 'PLAYING' || state.turnState !== 'PLAYING') {
+        return state;
+      }
+
       if (state.turnTimer > 0) {
         return { ...state, turnTimer: state.turnTimer - 1 };
-      } else {
-        return endTurn({ ...state, lastActionLog: `${state.players[state.currentPlayerIndex].name} se quedó sin tiempo. Turno finalizado.` });
       }
+
+      return endTurn({
+        ...state,
+        lastActionLog: `${state.players[state.currentPlayerIndex].name} se quedó sin tiempo. Turno finalizado.`,
+      });
     }
 
     default:
@@ -267,35 +244,34 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
   }
 }
 
-
 function endTurn(state: GameState): GameState {
   const newDeck = [...state.deck];
-  const newPlayers = JSON.parse(JSON.stringify(state.players));
+  const newPlayers = JSON.parse(JSON.stringify(state.players)) as GameState['players'];
   const currentPlayer = newPlayers[state.currentPlayerIndex];
   let isGameOver = false;
   let logMessage = state.lastActionLog;
   let newCenterRow = [...state.centerRow];
 
   if (state.playedCardsThisTurn > 0) {
-      // Player played cards, so they draw back up to HAND_SIZE
-      const cardsToDraw = state.playedCardsThisTurn;
-      for (let i = 0; i < cardsToDraw; i++) {
-        if (newDeck.length > 0) {
-          currentPlayer.hand.push(newDeck.pop()!);
-        } else {
-          isGameOver = true;
-          break;
-        }
+    const cardsToDraw = state.playedCardsThisTurn;
+    for (let i = 0; i < cardsToDraw; i++) {
+      if (newDeck.length > 0) {
+        currentPlayer.hand.push(newDeck.pop()!);
+      } else {
+        isGameOver = true;
+        break;
       }
-      logMessage = state.lastActionLog.includes('tiempo') ? state.lastActionLog : `${currentPlayer.name} terminó su turno.`;
+    }
+    if (!logMessage.includes('tiempo')) {
+      logMessage = `${currentPlayer.name} terminó su turno.`;
+    }
   } else {
-      // Player passed, so all cards played in previous turns are flipped face-down
-      newCenterRow = state.centerRow.map(card => ({...card, isFaceUp: false}));
-      logMessage = `${currentPlayer.name} ha pasado el turno. Las cartas de la fila se han volteado.`;
+    newCenterRow = state.centerRow.map((card) => ({ ...card, isFaceUp: false }));
+    logMessage = `${currentPlayer.name} ha pasado el turno. Las cartas de la fila se han volteado.`;
   }
 
   const nextPlayerIndex = ((state.currentPlayerIndex + 1) % 2) as 0 | 1;
-  
+
   const updatedState: GameState = {
     ...state,
     deck: newDeck,
@@ -315,27 +291,93 @@ function endTurn(state: GameState): GameState {
   return updatedState;
 }
 
+function startNextRound(state: GameState): GameState {
+  const newPlayers = JSON.parse(JSON.stringify(state.players)) as GameState['players'];
+  const cardsToAward = state.centerRow.map((card) => ({ ...card, isFaceUp: true } as Card));
+
+  let roundWinnerIndex: number;
+  let nextPlayerIndex: number;
+
+  if (state.roundEndReason === 'RAINBOW_COMPLETE') {
+    roundWinnerIndex = state.currentPlayerIndex;
+    nextPlayerIndex = (roundWinnerIndex + 1) % 2;
+    newPlayers[roundWinnerIndex].discardPile.push(...cardsToAward);
+  } else {
+    roundWinnerIndex = (state.currentPlayerIndex + 1) % 2;
+    nextPlayerIndex = state.currentPlayerIndex;
+    newPlayers[roundWinnerIndex].discardPile.push(...cardsToAward);
+  }
+
+  const roundWinnerId = newPlayers[roundWinnerIndex].id;
+
+  const newDeck = [...state.deck];
+  let isGameOver = false;
+
+  for (let i = 0; i < newPlayers.length; i++) {
+    const player = newPlayers[i];
+    const cardsNeeded = HAND_SIZE - player.hand.length;
+    if (cardsNeeded > 0) {
+      for (let j = 0; j < cardsNeeded; j++) {
+        if (newDeck.length > 0) {
+          player.hand.push(newDeck.pop()!);
+        } else {
+          isGameOver = true;
+          break;
+        }
+      }
+    }
+    if (isGameOver) {
+      break;
+    }
+  }
+
+  const updatedState: GameState = {
+    ...state,
+    players: newPlayers,
+    deck: newDeck,
+    centerRow: [],
+    currentPlayerIndex: nextPlayerIndex as 0 | 1,
+    turnState: 'PLAYING',
+    playedCardsThisTurn: 0,
+    roundEndReason: null,
+    roundWinnerId,
+    lastActionLog: `${newPlayers[roundWinnerIndex].name} ganó la ronda. ${newPlayers[nextPlayerIndex].name} empieza.`,
+    turnTimer: TURN_TIME_SECONDS,
+  };
+
+  if (isGameOver) {
+    return checkGameOver(updatedState);
+  }
+
+  return updatedState;
+}
 
 function checkGameOver(state: GameState): GameState {
-    if (state.players.length < 2) return state;
-    const p1Score = state.players[0].discardPile.length;
-    const p2Score = state.players[1].discardPile.length;
-    let winnerId = null;
-    let isTie = false;
+  if (state.players.length < 2) {
+    return state;
+  }
 
-    if (p1Score > p2Score) {
-      winnerId = state.players[0].id;
-    } else if (p2Score > p1Score) {
-      winnerId = state.players[1].id;
-    } else {
-      isTie = true;
-    }
-    
-    return {
-      ...state,
-      phase: 'GAME_OVER' as GamePhase,
-      gameWinnerId: winnerId,
-      isTie: isTie,
-      lastActionLog: isTie ? `¡Empate!` : `Fin de la partida. ¡${winnerId === state.players[0].id ? state.players[0].name : state.players[1].name} gana!`,
-    }
+  const p1Score = state.players[0].discardPile.length;
+  const p2Score = state.players[1].discardPile.length;
+
+  let winnerId: string | null = null;
+  let isTie = false;
+
+  if (p1Score > p2Score) {
+    winnerId = state.players[0].id;
+  } else if (p2Score > p1Score) {
+    winnerId = state.players[1].id;
+  } else {
+    isTie = true;
+  }
+
+  return {
+    ...state,
+    phase: 'GAME_OVER' as GamePhase,
+    gameWinnerId: winnerId,
+    isTie,
+    lastActionLog: isTie
+      ? '¡Empate!'
+      : `Fin de la partida. ¡${winnerId === state.players[0].id ? state.players[0].name : state.players[1].name} gana!`,
+  };
 }


### PR DESCRIPTION
## Summary
- introduce a reusable data provider and Firebase-backed matches service to abstract persistence details
- refactor lobby, gameplay, and auth components to consume the new data hooks instead of Firestore APIs directly
- expose shared error utilities and authentication helpers through the data layer and tighten game state typing

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dfedceef308330931942e005f8cb80

## Summary by Sourcery

Abstract Firebase interactions behind a new data layer, introducing service interfaces, context providers, and hooks for match and authentication operations, and migrate components to use the new abstractions with improved error handling and typing.

New Features:
- Add DataProvider and DataServices context to encapsulate data access
- Implement FirebaseMatchesService with methods to subscribe, create, find, join, update, merge, and delete matches
- Introduce hooks usePublicMatches, useMatch, and useMatchesActions for match operations
- Add useAuthentication hook for unified user authentication

Enhancements:
- Refactor Lobby, GameBoard, AuthGuard, FirebaseErrorListener, and app layout to consume the new data hooks instead of raw Firestore APIs
- Consolidate permission error handling into a DataPermissionError class and shared emitter
- Tighten typing for game state and player data in getInitialGameState